### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
Potential fix for [https://github.com/AtteBox/noppa/security/code-scanning/1](https://github.com/AtteBox/noppa/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the permissions to `contents: read`, which is sufficient for the workflow's operations (e.g., checking out the repository and running tests). This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
