### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,12 +2,14 @@
   import githubLogo from "./assets/github-mark-white.svg";
   import VirtualDice from "./lib/components/VirtualDice.svelte";
   import LanguageSelector from "./lib/components/LanguageSelector.svelte";
+  import ThemeToggle from "./lib/components/ThemeToggle.svelte";
   import { t } from "./lib/i18n/index.svelte";
 </script>
 
 <main>
   <div class="header-row">
     <h1>{t("appTitle")}</h1>
+    <ThemeToggle />
     <LanguageSelector />
   </div>
 
@@ -47,6 +49,10 @@
     height: 1.5rem;
     margin-left: 0.8rem;
     vertical-align: middle;
+  }
+
+  :global([data-theme="light"]) #github-link-logo {
+    filter: invert(1);
   }
 
   footer {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -33,7 +33,7 @@
 
 <style>
   .read-the-docs {
-    color: #888;
+    color: var(--muted-text-color);
     margin-bottom: 2rem;
   }
 

--- a/src/app.css
+++ b/src/app.css
@@ -114,6 +114,7 @@ button:focus-visible {
 
 button.primary {
   background-color: var(--primary-color);
+  color: var(--highlight-text);
 }
 
 button.primary:hover {
@@ -123,6 +124,7 @@ button.primary:hover {
 
 button.destructive {
   background-color: var(--destructive-color);
+  color: var(--highlight-text);
 }
 
 button.destructive:hover {

--- a/src/app.css
+++ b/src/app.css
@@ -12,6 +12,7 @@
   --input-hover-bg: #2a2a2a;
   --input-border-color: #646cff;
   --highlight-text: #ffffff;
+  --muted-text-color: #888;
   --shadow-color: rgba(0, 0, 0, 0.5);
 
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
@@ -40,6 +41,7 @@
   --input-hover-bg: #ebebeb;
   --input-border-color: #4f56c9;
   --highlight-text: #ffffff;
+  --muted-text-color: #666;
   --shadow-color: rgba(0, 0, 0, 0.15);
 
   color-scheme: light;
@@ -161,7 +163,7 @@ input:focus {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--shadow-color);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/app.css
+++ b/src/app.css
@@ -8,12 +8,11 @@
   --button-bg: #1a1a1a;
   --button-hover-bg: #2a2a2a;
   --button-hover-border: #646cff;
-  --button-hover-bg: #2a2a2a;
-  --button-hover-border: #646cff;
   --input-bg: #1a1a1a;
   --input-hover-bg: #2a2a2a;
   --input-border-color: #646cff;
   --highlight-text: #ffffff;
+  --shadow-color: rgba(0, 0, 0, 0.5);
 
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -25,6 +24,25 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+[data-theme="light"] {
+  --primary-color: #4f56c9;
+  --primary-hover-color: #3f47b3;
+  --destructive-color: #dc3545;
+  --destructive-hover-color: #c82333;
+  --text-color: #213547;
+  --background-color: #ffffff;
+  --button-bg: #f0f0f0;
+  --button-hover-bg: #e0e0e0;
+  --button-hover-border: #4f56c9;
+  --input-bg: #f5f5f5;
+  --input-hover-bg: #ebebeb;
+  --input-border-color: #4f56c9;
+  --highlight-text: #ffffff;
+  --shadow-color: rgba(0, 0, 0, 0.15);
+
+  color-scheme: light;
 }
 
 a {
@@ -124,7 +142,6 @@ input {
     color 0.3s;
   width: 100%;
   box-sizing: border-box;
-  text-shadow: #000 0px 0px 1px;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -158,6 +175,6 @@ input:focus {
   border-radius: 8px;
   max-width: 400px;
   width: 90%;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 5px 15px var(--shadow-color);
   text-align: center;
 }

--- a/src/lib/components/InputDialog.svelte
+++ b/src/lib/components/InputDialog.svelte
@@ -85,7 +85,7 @@
   }
 
   .validation-error {
-    color: red;
+    color: var(--destructive-color);
     font-size: 0.8rem;
   }
 </style>

--- a/src/lib/components/OptionList.svelte
+++ b/src/lib/components/OptionList.svelte
@@ -54,7 +54,7 @@
     margin-bottom: 0.5em;
     padding: 0.5em;
     border-radius: 5px;
-    color: white;
+    color: var(--highlight-text);
     display: flex;
     margin: 1rem;
     display: flex;
@@ -64,6 +64,6 @@
   input.option-input {
     font-size: 1.5rem;
     margin-right: 0.5em;
-    color: white;
+    color: var(--highlight-text);
   }
 </style>

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { getTheme, toggleTheme } from "../theme/index.svelte";
+  import { t } from "../i18n/index.svelte";
+</script>
+
+<button
+  class="theme-toggle"
+  onclick={toggleTheme}
+  aria-label={t("themeToggleAriaLabel")}
+  title={t("themeToggleAriaLabel")}
+>
+  {#if getTheme() === "dark"}
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="5"/>
+      <line x1="12" y1="1" x2="12" y2="3"/>
+      <line x1="12" y1="21" x2="12" y2="23"/>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+      <line x1="1" y1="12" x2="3" y2="12"/>
+      <line x1="21" y1="12" x2="23" y2="12"/>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+    </svg>
+  {:else}
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+  {/if}
+</button>
+
+<style>
+  .theme-toggle {
+    background: none;
+    border: 1px solid transparent;
+    color: var(--text-color);
+    cursor: pointer;
+    padding: 0.3em;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .theme-toggle:hover {
+    background-color: var(--button-hover-bg);
+    border-color: var(--button-hover-border);
+  }
+</style>

--- a/src/lib/components/VirtualDice.svelte
+++ b/src/lib/components/VirtualDice.svelte
@@ -253,7 +253,7 @@
   .breadcrumb .active {
     font-weight: bold;
     text-decoration: underline;
-    color: white;
+    color: var(--primary-color);
   }
 
   .prefilled-options {

--- a/src/lib/components/VirtualDice.svelte
+++ b/src/lib/components/VirtualDice.svelte
@@ -267,8 +267,8 @@
     border-radius: 4px;
     font-weight: bold;
     font-size: 2rem;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-    text-shadow: #000 0px 0px 1px;
+    box-shadow: 0 2px 5px var(--shadow-color);
+    text-shadow: rgba(0, 0, 0, 0.3) 0px 0px 1px;
     -webkit-font-smoothing: antialiased;
   }
 

--- a/src/lib/components/VirtualDice.svelte
+++ b/src/lib/components/VirtualDice.svelte
@@ -277,7 +277,7 @@
     padding: 0;
     font-size: 2.5rem;
     animation: rotate 0.8s infinite ease;
-    text-shadow: 0 0 3px #ddd;
+    text-shadow: 0 0 3px var(--shadow-color);
   }
 
   @keyframes rotate {

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -66,6 +66,9 @@ export type TranslationKeys = {
 
   // LanguageSelector
   languageSelectorAriaLabel: string;
+
+  // ThemeToggle
+  themeToggleAriaLabel: string;
 };
 
 const en: TranslationKeys = {
@@ -117,6 +120,8 @@ const en: TranslationKeys = {
   deletePrefilledOption: "Delete {name}",
 
   languageSelectorAriaLabel: "Language",
+
+  themeToggleAriaLabel: "Toggle light/dark theme",
 };
 
 const fi: TranslationKeys = {
@@ -168,6 +173,8 @@ const fi: TranslationKeys = {
   deletePrefilledOption: "Poista {name}",
 
   languageSelectorAriaLabel: "Kieli",
+
+  themeToggleAriaLabel: "Vaihda vaalea/tumma teema",
 };
 
 const sv: TranslationKeys = {
@@ -219,6 +226,8 @@ const sv: TranslationKeys = {
   deletePrefilledOption: "Ta bort {name}",
 
   languageSelectorAriaLabel: "Språk",
+
+  themeToggleAriaLabel: "Växla ljust/mörkt tema",
 };
 
 export type TranslationKey = keyof TranslationKeys;

--- a/src/lib/theme/index.svelte.ts
+++ b/src/lib/theme/index.svelte.ts
@@ -1,0 +1,43 @@
+const THEME_STORAGE_KEY = "noppa-theme";
+
+export type Theme = "light" | "dark";
+
+function detectTheme(): Theme {
+  const saved = localStorage.getItem(THEME_STORAGE_KEY);
+  if (saved === "light" || saved === "dark") {
+    return saved;
+  }
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+}
+
+let currentTheme: Theme = $state(detectTheme());
+
+function applyTheme(theme: Theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+  const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+  if (metaThemeColor) {
+    metaThemeColor.setAttribute(
+      "content",
+      theme === "dark" ? "#242424" : "#ffffff",
+    );
+  }
+}
+
+// Apply on load
+applyTheme(currentTheme);
+
+export function getTheme(): Theme {
+  return currentTheme;
+}
+
+export function setTheme(theme: Theme) {
+  currentTheme = theme;
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+  applyTheme(theme);
+}
+
+export function toggleTheme() {
+  setTheme(currentTheme === "dark" ? "light" : "dark");
+}

--- a/tests/themeToggle.spec.ts
+++ b/tests/themeToggle.spec.ts
@@ -3,8 +3,9 @@ import { test, expect } from "@playwright/test";
 test("user can toggle between light and dark theme", async ({ page }) => {
   await page.goto("/");
 
-  // Default should be dark (based on test environment having no preference)
   const html = page.locator("html");
+  const initialTheme = await html.getAttribute("data-theme");
+  const otherTheme = initialTheme === "dark" ? "light" : "dark";
 
   // Click the theme toggle button
   const themeToggle = page.getByRole("button", {
@@ -12,28 +13,31 @@ test("user can toggle between light and dark theme", async ({ page }) => {
   });
   await expect(themeToggle).toBeVisible();
 
-  // Toggle to light
+  // Toggle to other theme
   await themeToggle.click();
-  await expect(html).toHaveAttribute("data-theme", "light");
+  await expect(html).toHaveAttribute("data-theme", otherTheme);
 
-  // Toggle back to dark
+  // Toggle back to initial theme
   await themeToggle.click();
-  await expect(html).toHaveAttribute("data-theme", "dark");
+  await expect(html).toHaveAttribute("data-theme", initialTheme!);
 });
 
 test("theme preference persists across page reloads", async ({ page }) => {
   await page.goto("/");
 
   const html = page.locator("html");
+  const initialTheme = await html.getAttribute("data-theme");
+  const otherTheme = initialTheme === "dark" ? "light" : "dark";
+
   const themeToggle = page.getByRole("button", {
     name: "Toggle light/dark theme",
   });
 
-  // Toggle to light
+  // Toggle to other theme
   await themeToggle.click();
-  await expect(html).toHaveAttribute("data-theme", "light");
+  await expect(html).toHaveAttribute("data-theme", otherTheme);
 
   // Reload and verify persistence
   await page.reload();
-  await expect(html).toHaveAttribute("data-theme", "light");
+  await expect(html).toHaveAttribute("data-theme", otherTheme);
 });

--- a/tests/themeToggle.spec.ts
+++ b/tests/themeToggle.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+
+test("user can toggle between light and dark theme", async ({ page }) => {
+  await page.goto("/");
+
+  // Default should be dark (based on test environment having no preference)
+  const html = page.locator("html");
+
+  // Click the theme toggle button
+  const themeToggle = page.getByRole("button", {
+    name: "Toggle light/dark theme",
+  });
+  await expect(themeToggle).toBeVisible();
+
+  // Toggle to light
+  await themeToggle.click();
+  await expect(html).toHaveAttribute("data-theme", "light");
+
+  // Toggle back to dark
+  await themeToggle.click();
+  await expect(html).toHaveAttribute("data-theme", "dark");
+});
+
+test("theme preference persists across page reloads", async ({ page }) => {
+  await page.goto("/");
+
+  const html = page.locator("html");
+  const themeToggle = page.getByRole("button", {
+    name: "Toggle light/dark theme",
+  });
+
+  // Toggle to light
+  await themeToggle.click();
+  await expect(html).toHaveAttribute("data-theme", "light");
+
+  // Reload and verify persistence
+  await page.reload();
+  await expect(html).toHaveAttribute("data-theme", "light");
+});


### PR DESCRIPTION
## Summary
- Adds a light/dark theme toggle button (sun/moon icons) in the app header next to the language selector
- Defaults to OS preference via `prefers-color-scheme` media query, persists user choice to `localStorage`
- Defines light theme CSS variables via `[data-theme="light"]` selector and dynamically updates `theme-color` meta tag

## Changes
- **`src/app.css`** — Added `[data-theme="light"]` CSS variables block with light color values; added `--shadow-color` variable for theme-aware shadows
- **`src/lib/theme/index.svelte.ts`** — New theme state module (detect, get, set, toggle) with localStorage persistence and OS preference detection
- **`src/lib/components/ThemeToggle.svelte`** — New toggle button component with inline sun/moon SVG icons
- **`src/App.svelte`** — Added ThemeToggle to header; inverts GitHub logo in light mode
- **`src/lib/i18n/translations.ts`** — Added `themeToggleAriaLabel` for en, fi, sv
- **`src/lib/components/VirtualDice.svelte`** — Updated hardcoded shadow to use CSS variable
- **`tests/themeToggle.spec.ts`** — E2E tests for toggling and persistence across reloads

## Test plan
- [ ] Verify theme toggle switches between light and dark mode
- [ ] Verify OS preference is respected on first visit (no saved preference)
- [ ] Verify theme persists across page reloads
- [ ] Verify option colors remain readable in both themes
- [ ] Verify GitHub logo is visible in both themes
- [ ] Run `npm run e2e` to execute theme toggle E2E tests

https://claude.ai/code/session_0199teGNCfx4Ffr16yt3YnGb